### PR TITLE
Resolved #30

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -165,7 +165,7 @@ class Index extends React.Component {
                         {streamNotSupported ?
                           <form onSubmit={this.handleSubmit}>
                               <label htmlFor="barcode">바코드
-                                  <input id="barcode" type="tel" pattern="[0-9]*" maxLength="13" value={this.state.entered} onChange={this.handleChange.bind(this)} placeholder="8801069173603"/>
+                                  <input id="barcode" type="text" pattern="[0-9]*" maxLength="13" value={this.state.entered} onChange={this.handleChange.bind(this)} placeholder="8801069173603"/>
                               </label>
                               <button type="submit" className="submit-btn" disabled={this.state.entered.length < 13}>찾기</button>
                           </form> :


### PR DESCRIPTION
Attribute 를 type="tel"으로 지정해두면 iOS의 크롬에서 숫자만 입력할 수 있는 키패드만 나타나게 됩니다 (지구본 모양도 안나타납니다)
따라서 type='text' 로 지정을 하면 Barcode Key 등 서드파티 키보드를 활용한 바코드 인식이 가능하게 되어 바코드 인식에 도움이 될 것 같습니다.